### PR TITLE
ci: move the deploy to a new account and buckets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
       - develop
       - master
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -122,9 +126,18 @@ jobs:
         run: |
           cp ./server/config.json ./dist/config.json
 
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+
       - name: Deploy to Host
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          npm run deploy:host:dev
+        uses: reggionick/s3-deploy@v4
+        with:
+          folder: dist
+          bucket: ${{ secrets.DEV_S3_BUCKET_NAME }}
+          bucket-region: us-east-1
+          dist-id: ${{ secrets.DEV_CF_DISTRIBUTION_ID }}
+          delete-removed: true
+          no-cache: true
+          private: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -94,9 +98,18 @@ jobs:
           rm ./dist/fluidd.zip
           cp ./server/config.json ./dist/config.json
 
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
+
       - name: Deploy to Host
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          npm run deploy:host
+        uses: reggionick/s3-deploy@v4
+        with:
+          folder: dist
+          bucket: ${{ secrets.S3_BUCKET_NAME }}
+          bucket-region: us-east-1
+          dist-id: ${{ secrets.CF_DISTRIBUTION_ID }}
+          delete-removed: true
+          no-cache: true
+          private: true

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "lint": "eslint --ext .ts,.js,.vue ./src",
     "bootstrap": "husky",
     "copy:host:config": "shx cp -f ./server/config.json ./dist/config.json",
-    "deploy:host": "npx --yes -p @0x4447/potato potato -s dist -u -b app.fluidd.xyz -a \"$AWS_ACCESS_KEY_ID\" -t \"$AWS_SECRET_ACCESS_KEY\"",
-    "deploy:host:dev": "npx --yes -p @0x4447/potato potato -s dist -u -b dev-app.fluidd.xyz",
     "i18n-extract": "vue-i18n-extract use-config",
     "release": "standard-version",
     "release:major": "npm run release -- --release-as major",


### PR DESCRIPTION
As discussed over Discord, we need to move the S3 buckets that are hosting https://app.fluidd.xyz and https://dev-app.fluidd.xyz to a new account.
I took the opportunity to replace the deprecated tool to upload to S3 with a github action that supports a more modern authentication method.

There are a few secrets to be added to the repository settings which I will share via private message.
